### PR TITLE
Routing api https

### DIFF
--- a/http_routes/registration_test.go
+++ b/http_routes/registration_test.go
@@ -38,18 +38,20 @@ var _ = Describe("Registration", func() {
 			eventsSession = Rtr(args...)
 
 			var eventsSessionLogs []byte
-			Eventually(func() string {
-				logAdd, err := ioutil.ReadAll(eventsSession.Out)
-				Expect(err).ToNot(HaveOccurred())
-				eventsSessionLogs = append(eventsSessionLogs, logAdd...)
-				return string(eventsSessionLogs)
-			}, 70*time.Second).Should(SatisfyAll(
-				ContainSubstring(`"port":`),
-				ContainSubstring(`"route":`),
-				ContainSubstring(`"Action":"Upsert"`),
-			))
+			if routerApiConfig.UseHttp {
+				Eventually(func() string {
+					logAdd, err := ioutil.ReadAll(eventsSession.Out)
+					Expect(err).ToNot(HaveOccurred())
+					eventsSessionLogs = append(eventsSessionLogs, logAdd...)
+					return string(eventsSessionLogs)
+				}, 70*time.Second).Should(SatisfyAll(
+					ContainSubstring(`"port": 3000`),
+					ContainSubstring(`"route":`),
+					ContainSubstring(`"Action":"Upsert"`),
+				))
 
-			eventsSessionLogs = nil
+				eventsSessionLogs = nil
+			}
 
 			args = []string{"register", routeJSON}
 			session := Rtr(args...)

--- a/smoke_tests/smoke_test.go
+++ b/smoke_tests/smoke_test.go
@@ -9,7 +9,6 @@ import (
 	routing_helpers "code.cloudfoundry.org/cf-routing-test-helpers/helpers"
 	"code.cloudfoundry.org/routing-acceptance-tests/helpers"
 	"code.cloudfoundry.org/routing-acceptance-tests/helpers/assets"
-	"github.com/cloudfoundry/cf-test-helpers/v2/generator"
 	cfworkflow_helpers "github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -30,21 +29,14 @@ var (
 var _ = Describe("SmokeTests", func() {
 
 	BeforeEach(func() {
-		if routingConfig.TcpAppDomain != "" {
-			domainName = routingConfig.TcpAppDomain
-			cfworkflow_helpers.AsUser(adminContext, adminContext.Timeout, func() {
-				routing_helpers.VerifySharedDomain(routingConfig.TcpAppDomain, DEFAULT_TIMEOUT)
-			})
-			routerIps = append(routerIps, domainName)
-		} else {
-			domainName = fmt.Sprintf("%s.%s", generator.PrefixedRandomName("TCP", "DOMAIN"), routingConfig.AppsDomain)
+		Expect(routingConfig.TcpAppDomain).NotTo(BeEmpty(), "Before running these tests, you must configure tcp_apps_domain. The domain should resolve to the IP of the TCP load balancer in your deployment.")
 
-			cfworkflow_helpers.AsUser(adminContext, adminContext.Timeout, func() {
-				routing_helpers.CreateSharedDomain(domainName, routingConfig.TCPRouterGroup, DEFAULT_TIMEOUT)
-				routing_helpers.VerifySharedDomain(domainName, DEFAULT_TIMEOUT)
-			})
-			routerIps = routingConfig.Addresses
-		}
+		domainName = routingConfig.TcpAppDomain
+		cfworkflow_helpers.AsUser(adminContext, adminContext.Timeout, func() {
+			routing_helpers.VerifySharedDomain(routingConfig.TcpAppDomain, DEFAULT_TIMEOUT)
+		})
+
+		routerIps = append(routerIps, domainName)
 		appName = routing_helpers.GenerateAppName()
 		helpers.UpdateOrgQuota(adminContext)
 	})

--- a/tcp_routing/tcp_routing_suite_test.go
+++ b/tcp_routing/tcp_routing_suite_test.go
@@ -2,21 +2,19 @@ package tcp_routing_test
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 
 	"testing"
 
-	routing_helpers "code.cloudfoundry.org/cf-routing-test-helpers/helpers"
+	. "github.com/onsi/gomega/gexec"
+
 	"code.cloudfoundry.org/routing-acceptance-tests/helpers"
 	routing_api "code.cloudfoundry.org/routing-api"
-	"github.com/cloudfoundry/cf-test-helpers/v2/generator"
 	cfworkflow_helpers "github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
 )
 
@@ -73,21 +71,9 @@ var _ = BeforeSuite(func() {
 	environment.Setup()
 
 	helpers.ValidateRouterGroupName(adminContext, routingConfig.TCPRouterGroup)
-
-	domainName = fmt.Sprintf("%s.%s", generator.PrefixedRandomName("TCP", "DOMAIN"), routingConfig.AppsDomain)
-
-	cfworkflow_helpers.AsUser(adminContext, adminContext.Timeout, func() {
-		routerGroupName := routingConfig.TCPRouterGroup
-		routing_helpers.CreateSharedDomain(domainName, routerGroupName, DEFAULT_TIMEOUT)
-		routing_helpers.VerifySharedDomain(domainName, DEFAULT_TIMEOUT)
-	})
-
 })
 
 var _ = AfterSuite(func() {
-	cfworkflow_helpers.AsUser(adminContext, adminContext.Timeout, func() {
-		routing_helpers.DeleteSharedDomain(domainName, DEFAULT_TIMEOUT)
-	})
 	environment.Teardown()
 	CleanupBuildArtifacts()
 })


### PR DESCRIPTION
Changes to RATs to accomedate routing-api only serving https if  [`config.HttpEnabled`](https://github.com/cloudfoundry/routing-api/blob/395e1a4dc426d3ce8e6cf7d046e68536c30e6afd/cmd/routing-api/main.go#L167) is true:

1) In `[registration_test.go](https://github.com/cloudfoundry/routing-acceptance-tests/compare/main...routing-api-https#diff-0b095f81412610f4abdce842720b7d7f06b0dcf40fd7fa24854912c8042a85bf)`, route registration only happens of http is enabled.  (If http is not enabled, we let route-registrar take care of registering the https endpoint): https://github.com/pivotal/tas/blob/main/tas/jobs/route_registrar_control.yml#L66

2) (Unrelated but discovered during feature change): Remove extraneous test setup that inserts an arbitrarily-named TCP route to the routing table. The actual TCP routing test pings addresses set in `routingConfig.Addresses`, which should be, "IP addresses of the TCP Routers and/or the Load Balancer's IP address". The addresses generated in test setup are not used.

